### PR TITLE
Py3 compat

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -260,7 +260,7 @@ class Client():
         path = self.__normalize_path(path)
         res = self.__session.get(self.__webdav_url + path)
         if res.status_code == 200:
-            return res.content
+            return res.content.decode()
         return False
 
     def get_file(self, remote_path, local_file = None):
@@ -429,7 +429,7 @@ class Client():
 
         headers = {}
         if kwargs.get('keep_mtime', True):
-            headers['X-OC-MTIME'] = stat_result.st_mtime
+            headers['X-OC-MTIME'] = str(stat_result.st_mtime)
 
         if size == 0:
             return self.__make_dav_request(

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -451,8 +451,8 @@ class TestFileAccess(unittest.TestCase):
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.share_file_with_link(self.test_root + 'unexist.txt')
 
-        self.assertEquals(e.exception.status_code, 200)
-        self.assertEquals(e.exception.msg, "wrong path, file/folder doesn't exist.")
+        self.assertEqual(e.exception.status_code, 200)
+        self.assertEqual(e.exception.msg, "wrong path, file/folder doesn't exist.")
 
     @data_provider(files)
     def test_share_with_user(self, file_name):
@@ -510,8 +510,8 @@ class TestFileAccess(unittest.TestCase):
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.get_shares(self.test_root + 'does_not_exist')
 
-        self.assertEquals(e.exception.status_code, 200)
-        self.assertEquals(e.exception.msg, "share doesn't exist")
+        self.assertEqual(e.exception.status_code, 200)
+        self.assertEqual(e.exception.msg, "share doesn't exist")
 
     @data_provider(files)
     def test_get_shares(self, file_name):
@@ -528,8 +528,8 @@ class TestFileAccess(unittest.TestCase):
             shares = self.client.get_shares(self.test_root + file_name, subfiles=True)
         self.assertIsNone(shares)
 
-        self.assertEquals(e.exception.status_code, 200)
-        self.assertEquals(e.exception.msg, "not a directory")
+        self.assertEqual(e.exception.status_code, 200)
+        self.assertEqual(e.exception.msg, "not a directory")
 
 
         shares = self.client.get_shares(self.test_root, reshares=True, subfiles=True)

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -447,7 +447,8 @@ class TestFileAccess(unittest.TestCase):
         """Test sharing a file with link"""
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.share_file_with_link(self.test_root + 'unexist.txt')
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEquals(e.exception.status_code, 200)
+        self.assertEquals(e.exception.msg, "wrong path, file/folder doesn't exist.")
 
     @data_provider(files)
     def test_share_with_user(self, file_name):
@@ -504,7 +505,8 @@ class TestFileAccess(unittest.TestCase):
         """Test get_shares - path does not exist"""
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.get_shares(self.test_root + 'does_not_exist')
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEquals(e.exception.status_code, 200)
+        self.assertEquals(e.exception.msg, "share doesn't exist")
 
     @data_provider(files)
     def test_get_shares(self, file_name):
@@ -520,7 +522,8 @@ class TestFileAccess(unittest.TestCase):
         with self.assertRaises(owncloud.ResponseError) as e:
             shares = self.client.get_shares(self.test_root + file_name, subfiles=True)
         self.assertIsNone(shares)
-        self.assertEquals(e.exception.status_code, 400)
+        self.assertEquals(e.exception.status_code, 200)
+        self.assertEquals(e.exception.msg, "not a directory")
 
         shares = self.client.get_shares(self.test_root, reshares=True, subfiles=True)
         self.assertIsNotNone(shares)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+#gnureadline==6.3.3
+#ipdb==0.8
+#ipython==2.3.1
+requests==2.5.1
+unittest-data-provider==1.0.1
+#wsgiref==0.1.2
+six==1.9.0


### PR DESCRIPTION
Two tests fail, but mostly because how tests are dsigned, not because of bug.

This pull request contains also changes from master related to improved error handling.

As with master PR - Tested on owncloud 7.0.3, but on Python 3.4.2 in this case.

```

(.venv) macbook-tomek:pyocclient DI$ PYTHONPATH=. python owncloud/test/test.py TestFileAccess
....Assertion error caught with data set  ['文件.txt', b'\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c', '文件夹']
FAssertion error caught with data set  ['文件.txt', b'\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c', '文件夹']
F...............................
======================================================================
FAIL: test_download_file (__main__.TestFileAccess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/DI/PycharmProjects/pyocclient/.venv/lib/python3.4/site-packages/unittest_data_provider/__init__.py", line 7, in repl
    fn(self, *i)
  File "owncloud/test/test.py", line 213, in test_download_file
    self.assertEqual(s, content)
AssertionError: '你好世界' != b'\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c'

======================================================================
FAIL: test_get_file_contents (__main__.TestFileAccess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/DI/PycharmProjects/pyocclient/.venv/lib/python3.4/site-packages/unittest_data_provider/__init__.py", line 7, in repl
    fn(self, *i)
  File "owncloud/test/test.py", line 80, in test_get_file_contents
    self.assertEqual(self.client.get_file_contents(self.test_root + subdir + '/' + file_name), content)
AssertionError: '你好世界' != b'\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c'

----------------------------------------------------------------------
```
